### PR TITLE
A few misc improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ Options:
            --mock-dir, -d  A path to the directory containing mocks (by default,
                            test/image/mocks relative to the plotly directory)
 
+     -remote-topojson, -t  Use topojson from cdn.plot.ly (by default,
+                           dist/topojson relative to the plotly directory)
+
             --mathjax, -j  Load MathJax
 
           --keep-meta, -k  Skip metadata-stripping browserify transform to enable

--- a/cli.js
+++ b/cli.js
@@ -15,10 +15,12 @@ var args = require('minimist')(process.argv.slice(2), {
     j: 'mathjax',
     d: 'mock-dir',
     p: 'plotly-dir',
+    t: 'remote-topojson'
   },
   boolean: [
     'remote-mocks',
-    'keep-meta'
+    'keep-meta',
+    'remote-topojson'
   ]
 })
 
@@ -62,6 +64,10 @@ if (args.latest) {
 
 if (args['remote-mocks']) {
   opts.remoteMocks = true
+}
+
+if (args['remote-topojson']) {
+  opts.remoteTopojson = true
 }
 
 if (args['mapbox-access-token']) {

--- a/cli.js
+++ b/cli.js
@@ -19,12 +19,12 @@ var args = require('minimist')(process.argv.slice(2), {
   boolean: [
     'remote-mocks',
     'keep-meta'
-  ],
-});
+  ]
+})
 
 if (args.help) {
   process.stdout.write(fs.readFileSync(path.join(__dirname, 'lib/help.txt'), 'utf8'))
-  process.exit(0);
+  process.exit(0)
 }
 
 function printError (message) {
@@ -38,26 +38,26 @@ function printWarning (message) {
 var opts = {
   isCDN: false,
   title: '@dev'
-};
+}
 
 if (args._[0]) {
   opts.plotlySrc = args._[0]
-  opts.isCDN = true;
+  opts.isCDN = true
   opts.title = '@' + opts.plotlySrc
 }
 
 if (args.version) {
   opts.plotlySrc = 'https://cdn.plot.ly/plotly-' + args.version + '.js'
-  opts.isCDN = true;
+  opts.isCDN = true
   opts.title = '@' + args.version
-  console.log('plotly-mock-viewer: using CDN version of plotly ' + opts.plotlySrc);
+  console.log('plotly-mock-viewer: using CDN version of plotly ' + opts.plotlySrc)
 }
 
 if (args.latest) {
   opts.plotlySrc = 'https://cdn.plot.ly/plotly-latest.js'
-  opts.isCDN = true;
+  opts.isCDN = true
   opts.title = '@latest'
-  console.log('plotly-mock-viewer: using CDN version of plotly ' + opts.plotlySrc);
+  console.log('plotly-mock-viewer: using CDN version of plotly ' + opts.plotlySrc)
 }
 
 if (args['remote-mocks']) {
@@ -73,23 +73,23 @@ if (args['mock-dir']) {
 }
 
 if (args.mathjax) {
-  opts.mathjax = true;
+  opts.mathjax = true
 }
 
-opts.keepMeta = args['keep-meta'];
+opts.keepMeta = args['keep-meta']
 
-var plotlyPkg;
+var plotlyPkg
 if (args['plotly-dir']) {
-  plotlyPkg = path.join(args['plotly-dir'], 'package.json');
+  plotlyPkg = path.join(args['plotly-dir'], 'package.json')
 } else {
-  plotlyPkg = pkgUp.sync();
+  plotlyPkg = pkgUp.sync()
 }
 
 var pkg = JSON.parse(fs.readFileSync(plotlyPkg, 'utf8'))
 opts.plotlyPath = path.dirname(plotlyPkg)
 
 if (!pkg || pkg.name !== 'plotly.js') {
-  opts.plotlyPath = path.join(path.dirname(require.resolve('plotly.js')), '../');
+  opts.plotlyPath = path.join(path.dirname(require.resolve('plotly.js')), '../')
 }
 
-startServer(opts);
+startServer(opts)

--- a/lib/build.js
+++ b/lib/build.js
@@ -1,21 +1,21 @@
-'use strict';
+'use strict'
 
-var fs = require('fs');
-var path = require('path');
-var browserify = require('browserify');
-var brfs = require('brfs');
-var b = browserify();
-var es2040 = require('es2040');
-var indexhtmlify = require('indexhtmlify');
-var metadataify = require('metadataify');
-var pkgup = require('pkg-up');
-var pkg = JSON.parse(fs.readFileSync(pkgup.sync(), 'utf8'));
-var injectScript = require('html-inject-script');
-var ghCorner = require('github-cornerify');
-var injectFonts = require('./inject-fonts');
-var injectMathjax = require('./inject-mathjax');
+var fs = require('fs')
+var path = require('path')
+var browserify = require('browserify')
+var brfs = require('brfs')
+var b = browserify()
+var es2040 = require('es2040')
+var indexhtmlify = require('indexhtmlify')
+var metadataify = require('metadataify')
+var pkgup = require('pkg-up')
+var pkg = JSON.parse(fs.readFileSync(pkgup.sync(), 'utf8'))
+var injectScript = require('html-inject-script')
+var ghCorner = require('github-cornerify')
+var injectFonts = require('./inject-fonts')
+var injectMathjax = require('./inject-mathjax')
 
-b.add('./lib/production.js');
+b.add('./lib/production.js')
 b.transform('es2040')
 b.transform('brfs')
 b.bundle()
@@ -26,4 +26,3 @@ b.bundle()
   .pipe(injectScript(['https://cdn.plot.ly/plotly-latest.js']))
   .pipe(ghCorner())
   .pipe(fs.createWriteStream(path.join(__dirname, '../index.html')))
-

--- a/lib/development.js
+++ b/lib/development.js
@@ -6,5 +6,6 @@ require('./viewer')({
   Plotly: Plotly,
   mockListUrl: window.mockListUrl || '/mocklist.json',
   mockBaseUrl: window.mockBaseUrl || '/',
-  mockFilter: window.mockFilter || (m => m)
+  mockFilter: window.mockFilter || (m => m),
+  initialPlotConfig: window.initialPlotConfig || {}
 })

--- a/lib/help.txt
+++ b/lib/help.txt
@@ -18,6 +18,9 @@ Options:
            --mock-dir, -d  A path to the directory containing mocks (by default,
                            test/image/mocks relative to the plotly directory)
 
+     -remote-topojson, -t  Use topojson from cdn.plot.ly (by default,
+                           dist/topojson relative to the plotly directory)
+
             --mathjax, -j  Load MathJax
 
           --keep-meta, -k  Skip metadata-stripping browserify transform to enable

--- a/lib/inject-fonts.js
+++ b/lib/inject-fonts.js
@@ -1,10 +1,10 @@
-'use strict';
-var hyperstream = require('hyperstream');
+'use strict'
+var hyperstream = require('hyperstream')
 
 module.exports = function () {
   return hyperstream({
     head: {
       _appendHtml: '<link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Droid+Sans|PT+Sans+Narrow|Gravitas+One|Droid+Sans+Mono|Droid+Serif|Raleway|Old+Standard+TT"/>'
     }
-  });
+  })
 }

--- a/lib/inject-mathjax.js
+++ b/lib/inject-mathjax.js
@@ -1,5 +1,5 @@
-'use strict';
-var hyperstream = require('hyperstream');
+'use strict'
+var hyperstream = require('hyperstream')
 
 module.exports = function () {
   return hyperstream({
@@ -16,5 +16,5 @@ module.exports = function () {
         <script type="text/javascript" src="https://plot.ly/static/js/plugins/mathjax/MathJax.11cd36db117e.js"></script>
       `
     }
-  });
+  })
 }

--- a/lib/production.js
+++ b/lib/production.js
@@ -7,5 +7,8 @@ require('./viewer')({
   Plotly: window.Plotly,
   mockListUrl: 'https://api.github.com/repositories/45646037/contents/test/image/mocks',
   mockBaseUrl: 'https://raw.githubusercontent.com/plotly/plotly.js/master/test/image/mocks/',
-  mockFilter: m => m.name
+  mockFilter: m => m.name,
+  initialPlotConfig: {
+    logging: 2
+  }
 })

--- a/lib/production.js
+++ b/lib/production.js
@@ -9,6 +9,7 @@ require('./viewer')({
   mockBaseUrl: 'https://raw.githubusercontent.com/plotly/plotly.js/master/test/image/mocks/',
   mockFilter: m => m.name,
   initialPlotConfig: {
+    MAPBOX_ACCESS_TOKEN: 'pk.eyJ1IjoiZXRwaW5hcmQiLCJhIjoiY2luMHIyc2YwMGFzcXZobTRpYTBvZTFrOCJ9.GuIGZ1prg2ziFQ_bzdu5Lw',
     logging: 2
   }
 })

--- a/lib/production.js
+++ b/lib/production.js
@@ -9,7 +9,7 @@ require('./viewer')({
   mockBaseUrl: 'https://raw.githubusercontent.com/plotly/plotly.js/master/test/image/mocks/',
   mockFilter: m => m.name,
   initialPlotConfig: {
-    MAPBOX_ACCESS_TOKEN: 'pk.eyJ1IjoiZXRwaW5hcmQiLCJhIjoiY2luMHIyc2YwMGFzcXZobTRpYTBvZTFrOCJ9.GuIGZ1prg2ziFQ_bzdu5Lw',
+    mapboxAccessToken: 'pk.eyJ1IjoiZXRwaW5hcmQiLCJhIjoiY2luMHIyc2YwMGFzcXZobTRpYTBvZTFrOCJ9.GuIGZ1prg2ziFQ_bzdu5Lw',
     logging: 2
   }
 })

--- a/lib/server.js
+++ b/lib/server.js
@@ -63,7 +63,13 @@ function startServer (opts) {
     code.push('window.Plotly = require("' + plotlyPath + '")')
   }
 
-  code.push('window.plotlyCredentials = ' + JSON.stringify(credentials))
+  var initialPlotConfig = {
+    mapboxAccessToken: credentials.MAPBOX_ACCESS_TOKEN,
+    logging: 2
+  }
+
+
+  code.push('window.initialPlotConfig = ' + JSON.stringify(initialPlotConfig))
   code.push('window.viewerTitle = ' + JSON.stringify(opts.title))
 
   if (opts.remoteMocks) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -43,7 +43,7 @@ function startServer (opts) {
   }
 
   function resolveTopojson (url) {
-    var data = fs.readFileSync(path.join(topojsonPath, path.basename(url))).toString()
+    var data = fs.readFileSync(path.join(topojsonPath, path.basename(url)))
     return data
   }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -47,7 +47,7 @@ function startServer (opts) {
   ]
 
   var credentials = {}
-  if (!opts.mapboxAccessToken && !opts.isCDN) {
+  if (!opts.mapboxAccessToken) {
     try {
       credentials = JSON.parse(fs.readFileSync(path.join(plotlyPath, 'build/credentials.json'), 'utf8'))
     } catch (e) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -42,11 +42,6 @@ function startServer (opts) {
     return data
   }
 
-  function resolveTopojson (url) {
-    var data = fs.readFileSync(path.join(topojsonPath, path.basename(url)))
-    return data
-  }
-
   var plugins = [
     // This is our development server:
     b => b.add(path.join(__dirname, 'development.js'))
@@ -119,8 +114,9 @@ function startServer (opts) {
     middleware: [
       function (req, res, next) {
         if (/TOPOJSON/.test(req.url)) {
+          var name = path.basename(req.url)
           try {
-            res.end(resolveTopojson(req.url))
+            fs.createReadStream(path.join(topojsonPath, name)).pipe(res)
           } catch (e) {
             res.statusCode = 500
             res.end(JSON.stringify({error: 'Invalid topojson', message: e.message}))

--- a/lib/server.js
+++ b/lib/server.js
@@ -15,6 +15,7 @@ var injectMathJax = require('./inject-mathjax')
 function startServer (opts) {
   var plotlyPath = opts.plotlyPath
   var mockPath = opts.mockPath || path.join(plotlyPath, 'test/image/mocks/')
+  var topojsonPath = path.join(plotlyPath, 'dist', 'topojson')
 
   function fetchMockList () {
     return JSON.stringify(fs.readdirSync(mockPath).filter(name => /\.json$/.test(name)))
@@ -38,6 +39,11 @@ function startServer (opts) {
           next
       throw e
     }
+    return data
+  }
+
+  function resolveTopojson (url) {
+    var data = fs.readFileSync(path.join(topojsonPath, path.basename(url))).toString()
     return data
   }
 
@@ -68,6 +74,9 @@ function startServer (opts) {
     logging: 2
   }
 
+  if (!opts.remoteTopojson) {
+    initialPlotConfig.topojsonURL = 'TOPOJSON/'
+  }
 
   code.push('window.initialPlotConfig = ' + JSON.stringify(initialPlotConfig))
   code.push('window.viewerTitle = ' + JSON.stringify(opts.title))
@@ -109,8 +118,21 @@ function startServer (opts) {
     },
     middleware: [
       function (req, res, next) {
+        if (/TOPOJSON/.test(req.url)) {
+          try {
+            res.end(resolveTopojson(req.url))
+          } catch (e) {
+            res.statusCode = 500
+            res.end(JSON.stringify({error: 'Invalid topojson', message: e.message}))
+          }
+        } else {
+          next()
+        }
+      },
+      function (req, res, next) {
         /mocklist\.json$/.test(req.url) ? res.end(fetchMockList()) : next()
-      }, function (req, res, next) {
+      },
+      function (req, res, next) {
         if (/\.json$/.test(req.url)) {
           try {
             res.end(resolveMock(req.url))

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 var path = require('path')
 var fs = require('fs')
@@ -13,7 +13,7 @@ var injectFonts = require('./inject-fonts')
 var injectMathJax = require('./inject-mathjax')
 
 function startServer (opts) {
-  var plotlyPath = opts.plotlyPath;
+  var plotlyPath = opts.plotlyPath
   var mockPath = opts.mockPath || path.join(plotlyPath, 'test/image/mocks/')
 
   function fetchMockList () {
@@ -46,7 +46,7 @@ function startServer (opts) {
     b => b.add(path.join(__dirname, 'development.js'))
   ]
 
-  var credentials = {};
+  var credentials = {}
   if (!opts.mapboxAccessToken && !opts.isCDN) {
     try {
       credentials = JSON.parse(fs.readFileSync(path.join(plotlyPath, 'build/credentials.json'), 'utf8'))
@@ -58,13 +58,13 @@ function startServer (opts) {
     }
   }
 
-  var code = [];
+  var code = []
   if (!opts.plotlySrc) {
-    code.push('window.Plotly = require("' + plotlyPath + '")');
+    code.push('window.Plotly = require("' + plotlyPath + '")')
   }
 
-  code.push('window.plotlyCredentials = ' + JSON.stringify(credentials));
-  code.push('window.viewerTitle = ' + JSON.stringify(opts.title));
+  code.push('window.plotlyCredentials = ' + JSON.stringify(credentials))
+  code.push('window.viewerTitle = ' + JSON.stringify(opts.title))
 
   if (opts.remoteMocks) {
     code.push('window.mockListUrl = "https://api.github.com/repositories/45646037/contents/test/image/mocks"')
@@ -80,7 +80,7 @@ function startServer (opts) {
     )
   }
 
-  var transforms = [brfs, es2040];
+  var transforms = [brfs, es2040]
 
   if (!opts.keepMeta) {
     transforms.push(require('plotly.js/tasks/util/compress_attributes'))
@@ -103,7 +103,7 @@ function startServer (opts) {
     },
     middleware: [
       function (req, res, next) {
-        /mocklist\.json$/.test(req.url) ?  res.end(fetchMockList()) : next()
+        /mocklist\.json$/.test(req.url) ? res.end(fetchMockList()) : next()
       }, function (req, res, next) {
         if (/\.json$/.test(req.url)) {
           try {
@@ -124,13 +124,13 @@ function startServer (opts) {
         stream = stream.pipe(injectScripts([opts.plotlySrc]))
       }
 
-      stream = stream.pipe(injectFonts());
+      stream = stream.pipe(injectFonts())
 
       if (opts.mathjax) {
-        stream = stream.pipe(injectMathJax(true));
+        stream = stream.pipe(injectMathJax(true))
       }
 
-      return stream;
+      return stream
     }
   }).on('connect', function (ev) {
     console.log('Server running on %s', ev.uri)

--- a/lib/viewer.js
+++ b/lib/viewer.js
@@ -12,9 +12,12 @@ module.exports = function (config) {
   window.Plotly = Plotly
   require('../assets/strict-d3')
 
+  window.d3 = Plotly.d3
+
   console.groupCollapsed('📊📊 %cplotly.js mock viewer (expand for instructions)%c 📊📊', 'background-color:rgb(65,120,223);color:white;font-weight:bold', 'background-color:none')
   console.log('This viewer exposes a number of global variables for easy inspection:')
   console.log('    Plotly    the plotly instance')
+  console.log('        d3    d3 v3 object')
   console.log('        gd    the graph div')
   console.log('      mock    the currently loaded mock')
   console.log('  mocklist    a list of all available mocks')

--- a/lib/viewer.js
+++ b/lib/viewer.js
@@ -21,13 +21,11 @@ module.exports = function (config) {
   console.log('plotMock()    fetch and plot a mock by name, e.g. plotMock(\'gl3d_bunny\')')
   console.groupEnd('-- Expand for instructions --')
 
-  if (!window.plotlyCredentials || !window.plotlyCredentials.MAPBOX_ACCESS_TOKEN) {
-    console.warn('Warning: No valid mapbox access token found. To set manually, run `Plotly.setConfig({mapboxAccessToken: YOUR_TOKEN_HERE})`')
-  } else {
-    Plotly.setPlotConfig({
-      mapboxAccessToken: window.plotlyCredentials.MAPBOX_ACCESS_TOKEN
-    })
+  if (!window.initialPlotConfig.mapboxAccessToken) {
+    console.warn('Warning: No mapbox access token found. To set manually, run `Plotly.setConfig({mapboxAccessToken: YOUR_TOKEN_HERE})`')
   }
+
+  Plotly.setPlotConfig(window.initialPlotConfig)
 
   css(fs.readFileSync(__dirname + '/../assets/auto-complete.css', 'utf8'))
   css(fs.readFileSync(__dirname + '/../assets/styles.css', 'utf8'))

--- a/lib/viewer.js
+++ b/lib/viewer.js
@@ -10,22 +10,22 @@ module.exports = function (config) {
 
   // Make sure it's global, I guess?
   window.Plotly = Plotly
-  require('../assets/strict-d3');
+  require('../assets/strict-d3')
 
-  console.groupCollapsed('📊📊 %cplotly.js mock viewer (expand for instructions)%c 📊📊', 'background-color:rgb(65,120,223);color:white;font-weight:bold', 'background-color:none');
+  console.groupCollapsed('📊📊 %cplotly.js mock viewer (expand for instructions)%c 📊📊', 'background-color:rgb(65,120,223);color:white;font-weight:bold', 'background-color:none')
   console.log('This viewer exposes a number of global variables for easy inspection:')
   console.log('    Plotly    the plotly instance')
   console.log('        gd    the graph div')
   console.log('      mock    the currently loaded mock')
   console.log('  mocklist    a list of all available mocks')
   console.log('plotMock()    fetch and plot a mock by name, e.g. plotMock(\'gl3d_bunny\')')
-  console.groupEnd('-- Expand for instructions --');
+  console.groupEnd('-- Expand for instructions --')
 
   if (!window.plotlyCredentials || !window.plotlyCredentials.MAPBOX_ACCESS_TOKEN) {
     console.warn('Warning: No valid mapbox access token found. To set manually, run `Plotly.setConfig({mapboxAccessToken: YOUR_TOKEN_HERE})`')
   } else {
     Plotly.setPlotConfig({
-      mapboxAccessToken: window.plotlyCredentials.MAPBOX_ACCESS_TOKEN,
+      mapboxAccessToken: window.plotlyCredentials.MAPBOX_ACCESS_TOKEN
     })
   }
 
@@ -38,24 +38,24 @@ module.exports = function (config) {
     h('h3', h('a', {href: 'https://github.com/plotly/plotly.js', target: '_blank'}, title))
   ])
 
-  var bar = h('div', {id: 'bar', class: 'clearfix'}, barContainer);
+  var bar = h('div', {id: 'bar', class: 'clearfix'}, barContainer)
 
   function setTitle (t) {
-    var el = document.querySelector('title');
+    var el = document.querySelector('title')
     if (!el) {
       el = h('title')
-      document.head.appendChild(el);
+      document.head.appendChild(el)
     }
-    el.textContent = t;
+    el.textContent = t
   }
 
-  setTitle(title);
+  setTitle(title)
 
   document.body.appendChild(bar)
 
   function fetchMockList () {
     return fetch(config.mockListUrl).then(function (response) {
-      console.info('Fetched mocks from', config.mockListUrl);
+      console.info('Fetched mocks from', config.mockListUrl)
       return response.json().then(function (json) {
         return (window.mocklist = json.map(config.mockFilter))
       })
@@ -65,7 +65,7 @@ module.exports = function (config) {
   function fetchMock (mockname) {
     var remoteUrl = config.mockBaseUrl + mockname.replace(/^\//, '')
     return fetch(remoteUrl).then(function (response) {
-      console.info('Fetched mock from', remoteUrl);
+      console.info('Fetched mock from', remoteUrl)
       if (response.status === 500) {
         return new Promise(function (resolve, reject) {
           response.json().then(function (error) {
@@ -97,7 +97,7 @@ module.exports = function (config) {
     return fetchMock(filename).then(function (mock) {
       console.info('Plotting mock', filename, mock)
 
-      updateGraphDiv();
+      updateGraphDiv()
 
       window.removeEventListener('hashchange', plotFromHash)
       window.location.hash = filename.replace(/\.json$/, '')
@@ -149,12 +149,12 @@ module.exports = function (config) {
   updateMockMenu()
 
   window.addEventListener('hashchange', plotFromHash)
-  updateGraphDiv();
+  updateGraphDiv()
   plotFromHash()
 
   // Instead of exposing the function directly, add this layer of indirection
   // to avoid double-plots due to the hashchange listener
   window.plotMock = function (hash) {
-    window.location.hash = hash;
+    window.location.hash = hash
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
     "lint": "standard",
     "lint-fix": "standard --fix"
   },
+  "standard": {
+    "ignore": [
+      "assets/"
+    ]
+  },
   "bin": {
     "plotly-mock-viewer": "cli.js"
   },
@@ -37,6 +42,7 @@
     "github-cornerify": "^1.0.7",
     "indexhtmlify": "^1.3.1",
     "metadataify": "^1.0.3",
-    "plotly.js": "^1.25.0"
+    "plotly.js": "^1.25.0",
+    "standard": "^10.0.2"
   }
 }


### PR DESCRIPTION
@rreusser This PR:

- generalise how `Plotly.setPlotConfig` gets its options
- set `logging` config option to `2` (for max console debugging info)
- pass mapbox access token in prod and CDN pages
- make dev page use local topojson from [`plotly.js/dist/topojson/`](https://github.com/plotly/plotly.js/tree/master/dist/topojson)
- add `remote-topojson` to use optionally use `https://cdn.plot.ly/` topojsons e.g. https://cdn.plot.ly/world_110m.json
- add `window.d3` ref
- (actually) lint with `standard`

